### PR TITLE
fix(parser): Allow empty nodes in NodeDeps model

### DIFF
--- a/dbt_airflow/parser/dbt.py
+++ b/dbt_airflow/parser/dbt.py
@@ -16,7 +16,11 @@ class DbtResourceType(str, Enum):
 
 
 class NodeDeps(BaseModel):
-    nodes: List[str]
+    # Note: The following initialisation of a mutable object such as a list,
+    # would normally suggest a bug, but `pydantic` handles this properly,
+    # meaning that a deep copy will be created and each model instance will
+    # get its own empty list.
+    nodes: Optional[List[str]] = []
 
     def __getitem__(self, item):
         return getattr(self, item)


### PR DESCRIPTION
- As of dbt v1.4.0 and manifest v8, Seed models have no `depends_on.nodes` field. 